### PR TITLE
Use a source file relative path to the icon file.

### DIFF
--- a/src/3d.s
+++ b/src/3d.s
@@ -389,7 +389,7 @@ goodbye:
 
 	;; Icon header
 	
-  .include icon "img/vms_icon.gif" speed=16
+  .include icon "../img/vms_icon.gif" speed=16
 	
         ;; Your main program starts here.
 


### PR DESCRIPTION
Now that `waterbear v0.22.0` has fixed path handling, we should ensure that the image path is relative to the source file, instead of to the working directory.

# Status Quo
The `.vms` still builds, but a warning is printed:
```
% waterbear assemble src/3d.s -o Tiny3D.vms
WARNING: Path "/Users/walter/wip/tiny3dengine/src/img/vms_icon.gif" not found. Falling back to "img/vms_icon.gif"
         Please change the path to be relative to the source file, instead of relative to your working directory.
WARNING: Path "/Users/walter/wip/tiny3dengine/src/img/vms_icon.gif" not found. Falling back to "img/vms_icon.gif"
         Please change the path to be relative to the source file, instead of relative to your working directory.
[OK] Assembled 9728 bytes to Tiny3D.vms.
% shasum Tiny3D.vms
624b69dc79d4d58a21f8ad0ab14ac6729707976a  Tiny3D.vms
```

# With fix
Still assembles fine, with no warnings:
```
% waterbear assemble src/3d.s -o Tiny3D.vms
[OK] Assembled 9728 bytes to Tiny3D.vms.
% shasum Tiny3D.vms
624b69dc79d4d58a21f8ad0ab14ac6729707976a  Tiny3D.vms
```